### PR TITLE
fix: inactive editor world passed through with nullptr

### DIFF
--- a/Source/wunthshin/Subsystem/Utility.h
+++ b/Source/wunthshin/Subsystem/Utility.h
@@ -7,7 +7,8 @@ struct FEditorSubsystemBranching
 	template <typename EditorWorldType, typename GameWorldType>
 	static USubsystem* GetTemplate(const UWorld* InWorld)
 	{
-		if (InWorld->IsEditorWorld())
+		// Inactive는 에디터에서 지금 수정하지 않는 상태에 들어간 경우에 발생함
+		if (InWorld->IsEditorWorld() || InWorld->WorldType == EWorldType::Inactive)
 		{
 			return GEditor->GetEditorSubsystem<EditorWorldType>();
 		}
@@ -21,7 +22,8 @@ struct FEditorSubsystemBranching
 
 	static USubsystem* GetReflection(const UWorld* InWorld, UClass* InEditorType, UClass* InGameWorldType)
 	{
-		if (InWorld->IsEditorWorld())
+		// Inactive는 에디터에서 지금 수정하지 않는 상태에 들어간 경우에 발생함
+		if (InWorld->IsEditorWorld() || InWorld->WorldType == EWorldType::Inactive)
 		{
 			return GEditor->GetEditorSubsystemBase(InEditorType);
 		}


### PR DESCRIPTION
## 개요
에디터 서브시스템 분기처리에서 비활성화된 월드가 IsEditorWorld() 조건에 걸리지 않고 넘어감 
