### PR TITLE
fix: rollback inventory component

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -105,6 +105,11 @@ ManualIPAddress=
 +PropertyRedirects=(OldName="/Script/wunthshin.BaseAnimInstance.bAlive",NewName="/Script/wunthshin.BaseAnimInstance.bIsAlive")
 +FunctionRedirects=(OldName="/Script/wunthshin.A_WSNPCAIController.DisableAI",NewName="/Script/wunthshin.A_WSNPCAIController.ToggleAI")
 +ClassRedirects=(OldName="/Script/wunthshin.BTTask_WSCheckAlive",NewName="/Script/wunthshin.BTDecorator_WSCheckAlive")
++PropertyRedirects=(OldName="/Script/wunthshin.A_WSNPCPawn.DamageIndicators",NewName="/Script/wunthshin.A_WSNPCPawn.DamageCounter")
++ClassRedirects=(OldName="/Script/wunthshin.DamageIndicatorPool",NewName="/Script/wunthshin.DamageCounterPool")
++PropertyRedirects=(OldName="/Script/wunthshin.A_WSCharacter.DamageIndicators",NewName="/Script/wunthshin.A_WSCharacter.DamageCounters")
++StructRedirects=(OldName="/Script/wunthshin.DamageIndicatorContext",NewName="/Script/wunthshin.DamageCounterContext")
++ClassRedirects=(OldName="/Script/wunthshin.WG_WSDamageIndicator",NewName="/Script/wunthshin.WG_WSDamageCounter")
 
 [/Script/Engine.CollisionProfile]
 -Profiles=(Name="NoCollision",CollisionEnabled=NoCollision,ObjectTypeName="WorldStatic",CustomResponses=((Channel="Visibility",Response=ECR_Ignore),(Channel="Camera",Response=ECR_Ignore)),HelpMessage="No collision",bCanModify=False)

--- a/Source/wunthshin/Actors/Pawns/Character/AA_WSCharacter.cpp
+++ b/Source/wunthshin/Actors/Pawns/Character/AA_WSCharacter.cpp
@@ -30,10 +30,11 @@
 #if WITH_EDITOR & !UE_BUILD_SHIPPING_WITH_EDITOR
 #include "wunthshinEditorModule/Subsystem/EditorSubsystem/Character/CharacterEditorSubsystem.h"
 #endif
+#include "wunthshin/Components/CharacterInventory/C_WSCharacterInventory.h"
 #include "wunthshin/Components/Skill/C_WSSkill.h"
 #include "wunthshin/Subsystem/GameInstanceSubsystem/Character/CharacterSubsystem.h"
 #include "wunthshin/Subsystem/WorldSubsystem/WorldStatus/WorldStatusSubsystem.h"
-#include "wunthshin/Widgets/DamageIndicator/WG_WSDamageIndicator.h"
+#include "wunthshin/Widgets/DamageCounter/WG_WSDamageCounter.h"
 
 DEFINE_LOG_CATEGORY(LogTemplateCharacter);
 
@@ -118,7 +119,7 @@ AA_WSCharacter::AA_WSCharacter(const FObjectInitializer & ObjectInitializer)
     FollowCamera->bUsePawnControlRotation = false; // Camera does not rotate relative to arm
 
     // Create a Inventory
-    Inventory = CreateDefaultSubobject<UC_WSInventory>(TEXT("Inventory"));
+    Inventory = CreateDefaultSubobject<UC_WSCharacterInventory>(InventoryComponentName);
     // Note: The skeletal mesh and anim blueprint references on the Mesh component (inherited from Character) 
     // are set in the derived blueprint asset named ThirdPersonCharacter (to avoid direct content references in C++)
 
@@ -137,7 +138,7 @@ AA_WSCharacter::AA_WSCharacter(const FObjectInitializer & ObjectInitializer)
 
     Skill = CreateDefaultSubobject<UC_WSSkill>(TEXT("SkillComponent"));
     
-    DamageIndicators = CreateDefaultSubobject<UDamageIndicatorPool>(TEXT("DamageIndicators"));
+    DamageCounters = CreateDefaultSubobject<UDamageCounterPool>(TEXT("DamageIndicators"));
 
     AutoPossessPlayer = EAutoReceiveInput::Type::Disabled;
     AutoPossessAI = EAutoPossessAI::Disabled;
@@ -288,7 +289,7 @@ float AA_WSCharacter::TakeDamage(float Damage, FDamageEvent const& DamageEvent, 
             UE_LOG(LogTemplateCharacter, Warning, TEXT("TakeDamage! : %s did %f with %s to %s"), *EventInstigator->GetName(), Damage, *DamageCauser->GetName(), *GetName());
             CustomEvent.SetFirstHit(this);
             PlayHitMontage();
-            DamageIndicators->Allocate(Damage);
+            DamageCounters->Allocate(Damage);
 
             // 무기를 맞았을 경우 무기의 원소 효과를 부여
             if (const AA_WSWeapon* Weapon = Cast<AA_WSWeapon>(DamageCauser))

--- a/Source/wunthshin/Actors/Pawns/Character/AA_WSCharacter.h
+++ b/Source/wunthshin/Actors/Pawns/Character/AA_WSCharacter.h
@@ -14,7 +14,7 @@
 
 #include "AA_WSCharacter.generated.h"
 
-class UDamageIndicatorPool;
+class UDamageCounterPool;
 class UClimCharacterMovementComponent;
 class UC_WSSkill;
 class UPawnMovementComponent;
@@ -118,7 +118,7 @@ class AA_WSCharacter : public ACharacter, public I_WSTaker, public IDataTableFet
 	UChildActorComponent* RightHandWeapon;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (AllowPrivateAccess = "true"))
-	UDamageIndicatorPool* DamageIndicators;
+	UDamageCounterPool* DamageCounters;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Asset", meta = (AllowPrivateAccess = "true"))
 	FName AssetName;
@@ -271,7 +271,7 @@ public:
 	virtual UChildActorComponent* GetRightHandComponent() const override { return RightHandWeapon; }
 	virtual UPawnMovementComponent* GetPawnMovementComponent() const override { return ACharacter::GetMovementComponent(); }
 	virtual UC_WSSkill* GetSkillComponent() const override { return Skill; }
-	virtual UDamageIndicatorPool* GetDamageIndicators() const override { return DamageIndicators; }
+	virtual UDamageCounterPool* GetDamageCounters() const override { return DamageCounters; }
 	
 	virtual void HandleStaminaDepleted() override;
 	UInputMappingContext* GetMappingContext() const { return DefaultMappingContext; }

--- a/Source/wunthshin/Actors/Pawns/NPC/A_WSNPCPawn.cpp
+++ b/Source/wunthshin/Actors/Pawns/NPC/A_WSNPCPawn.cpp
@@ -23,7 +23,7 @@
 #include "wunthshin/Components/Skill/C_WSSkill.h"
 #include "wunthshin/Data/Items/DamageEvent/WSDamageEvent.h"
 #include "wunthshin/Subsystem/WorldSubsystem/WorldStatus/WorldStatusSubsystem.h"
-#include "wunthshin/Widgets/DamageIndicator/WG_WSDamageIndicator.h"
+#include "wunthshin/Widgets/DamageCounter/WG_WSDamageCounter.h"
 
 DEFINE_LOG_CATEGORY(LogNPCPawn);
 
@@ -36,7 +36,7 @@ AA_WSNPCPawn::AA_WSNPCPawn()
 	MovementComponent = CreateOptionalDefaultSubobject<UFloatingPawnMovement>(TEXT("MovementComponent"));
 	CapsuleComponent = CreateDefaultSubobject<UCapsuleComponent>(TEXT("CapsuleComponent"));
 	MeshComponent = CreateDefaultSubobject<USkeletalMeshComponent>(TEXT("SkeletalMesh"));
-	Inventory = CreateDefaultSubobject<UC_WSInventory>(TEXT("Inventory"));
+	Inventory = CreateDefaultSubobject<UC_WSInventory>(InventoryComponentName);
 	Shield = CreateDefaultSubobject<UC_WSShield>(TEXT("Shield"));
 	StatsComponent = CreateDefaultSubobject<UStatsComponent>(TEXT("StatsComponent"));
 	RightHandWeapon = CreateDefaultSubobject<UChildActorComponent>(TEXT("RightHandWeapon"));
@@ -61,7 +61,7 @@ AA_WSNPCPawn::AA_WSNPCPawn()
 	bUseControllerRotationYaw = true;
 	bUseControllerRotationRoll = true;
 	
-	DamageIndicators = CreateDefaultSubobject<UDamageIndicatorPool>(TEXT("DamageIndicators"));
+	DamageCounter = CreateDefaultSubobject<UDamageCounterPool>(TEXT("DamageCounters"));
 }
 
 void AA_WSNPCPawn::OnConstruction(const FTransform& Transform)
@@ -189,7 +189,7 @@ float AA_WSNPCPawn::TakeDamage(float DamageAmount, struct FDamageEvent const& Da
 			UE_LOG(LogNPCPawn, Warning, TEXT("TakeDamage! : %s did %f with %s to %s"), *EventInstigator->GetName(), DamageAmount, *DamageCauser->GetName(), *GetName());
 			CustomEvent.SetFirstHit(this);
 			PlayHitMontage();
-            DamageIndicators->Allocate(DamageAmount);
+            DamageCounter->Allocate(DamageAmount);
 
 			// 무기를 맞았을 경우 무기의 원소 효과를 부여
 			if (const AA_WSWeapon* Weapon = Cast<AA_WSWeapon>(DamageCauser))

--- a/Source/wunthshin/Actors/Pawns/NPC/A_WSNPCPawn.h
+++ b/Source/wunthshin/Actors/Pawns/NPC/A_WSNPCPawn.h
@@ -49,7 +49,7 @@ class WUNTHSHIN_API AA_WSNPCPawn : public APawn, public IDataTableFetcher, publi
 	UChildActorComponent* RightHandWeapon;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Widget", meta = (AllowPrivateAccess = "true"))
-	UDamageIndicatorPool* DamageIndicators;
+	UDamageCounterPool* DamageCounter;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Asset", meta = (AllowPrivateAccess = "true"))
 	FName AssetName;
@@ -107,7 +107,7 @@ public:
 	virtual UChildActorComponent* GetRightHandComponent() const override;
 	virtual UPawnMovementComponent* GetPawnMovementComponent() const override;
 	virtual UC_WSSkill* GetSkillComponent() const override { return Skill; }
-	virtual UDamageIndicatorPool* GetDamageIndicators() const override { return DamageIndicators; }
+	virtual UDamageCounterPool* GetDamageCounters() const override { return DamageCounter; }
 	
 	virtual void HandleStaminaDepleted() override;
 

--- a/Source/wunthshin/Components/CharacterInventory/C_WSCharacterInventory.cpp
+++ b/Source/wunthshin/Components/CharacterInventory/C_WSCharacterInventory.cpp
@@ -1,0 +1,112 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "C_WSCharacterInventory.h"
+
+#include "wunthshin/Actors/Item/A_WSItem.h"
+#include "wunthshin/Subsystem/GameInstanceSubsystem/Character/CharacterSubsystem.h"
+#include "wunthshin/Subsystem/GameInstanceSubsystem/Item/ItemSubsystem.h"
+
+
+// Sets default values for this component's properties
+UC_WSCharacterInventory::UC_WSCharacterInventory()
+{
+	// Set this component to be initialized when the game starts, and to be ticked every frame.  You can turn these features
+	// off to improve performance if you don't need them.
+	PrimaryComponentTick.bCanEverTick = false;
+
+	// ...
+}
+
+
+// Called when the game starts
+void UC_WSCharacterInventory::BeginPlay()
+{
+	Super::BeginPlay();
+
+	// ...
+	
+}
+
+const TArray<FInventoryPair>& UC_WSCharacterInventory::GetItems() const
+{
+	if (UItemSubsystem* ItemSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UItemSubsystem>())
+	{
+		return ItemSubsystem->GetSharedInventory().GetItems();
+	}
+
+	return Super::GetItems();
+}
+
+int32 UC_WSCharacterInventory::FindItemIndex(const USG_WSItemMetadata* InMetadata) const
+{
+	if (UItemSubsystem* ItemSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UItemSubsystem>())
+	{
+		return ItemSubsystem->GetSharedInventory().FindItemIndex(InMetadata);
+	}
+
+	return -1;
+}
+
+FInventoryPair* UC_WSCharacterInventory::FindItem(const USG_WSItemMetadata* InMetadata)
+{
+	if (UItemSubsystem* ItemSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UItemSubsystem>())
+	{
+		return ItemSubsystem->GetSharedInventory().FindItem(InMetadata);
+	}
+
+	return nullptr;
+}
+
+void UC_WSCharacterInventory::AddItem(AA_WSItem* InItem, int InCount)
+{
+	// 타입 캐스팅 안전
+	if (InCount < 0) 
+	{
+		return;
+	}
+
+	const USG_WSItemMetadata* ItemMetadata = InItem->GetItemMetadata();
+	// Item metadata가 생성되지 않았음
+	check(ItemMetadata);
+
+	if (UItemSubsystem* ItemSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UItemSubsystem>())
+	{
+		ItemSubsystem->GetSharedInventory().AddItem(ItemMetadata, InCount);
+	}
+}
+
+void UC_WSCharacterInventory::RemoveItem(AA_WSItem* InItem, int InCount)
+{
+	// 타입 캐스팅 안전
+	if (InCount < 0) 
+	{
+		return;
+	}
+
+	const USG_WSItemMetadata* ItemMetadata = InItem->GetItemMetadata();
+	check(ItemMetadata);
+
+	if (UItemSubsystem* ItemSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UItemSubsystem>())
+	{
+		ItemSubsystem->GetSharedInventory().RemoveItem(ItemMetadata, InCount);
+	}
+}
+
+void UC_WSCharacterInventory::UseItem(uint32 Index, AActor* InTarget, int InCount)
+{
+	UE_LOG(LogInventory, Log, TEXT("UC_WSInventory::UseItem"));
+
+	// 음수 갯수 예외처리
+	if (InCount < 0) 
+	{
+		return;
+	}
+	
+	if (UItemSubsystem* ItemSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UItemSubsystem>())
+	{
+		ItemSubsystem->GetSharedInventory().UseItem(Index, GetOwner(), InTarget, InCount);
+	}
+}
+
+

--- a/Source/wunthshin/Components/CharacterInventory/C_WSCharacterInventory.h
+++ b/Source/wunthshin/Components/CharacterInventory/C_WSCharacterInventory.h
@@ -1,0 +1,32 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "wunthshin/Components/Inventory/C_WSInventory.h"
+#include "C_WSCharacterInventory.generated.h"
+
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class WUNTHSHIN_API UC_WSCharacterInventory : public UC_WSInventory
+{
+	GENERATED_BODY()
+
+public:
+	// Sets default values for this component's properties
+	UC_WSCharacterInventory();
+
+protected:
+	// Called when the game starts
+	virtual void BeginPlay() override;
+
+public:
+	virtual const TArray<FInventoryPair>& GetItems() const override;
+
+	virtual int32 FindItemIndex(const USG_WSItemMetadata* InMetadata) const override;
+	virtual FInventoryPair* FindItem(const USG_WSItemMetadata* InMetadata) override;
+	
+	virtual void AddItem(AA_WSItem* InItem, int InCount = 1) override;
+	virtual void RemoveItem(AA_WSItem* InItem, int InCount = 1) override;
+	virtual void UseItem(uint32 Index, AActor* InTarget, int InCount = 1) override;
+};

--- a/Source/wunthshin/Components/Inventory/C_WSInventory.h
+++ b/Source/wunthshin/Components/Inventory/C_WSInventory.h
@@ -56,23 +56,25 @@ class WUNTHSHIN_API UC_WSInventory : public UActorComponent
 {
 	GENERATED_BODY()
 
-public:	
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
+	TArray<FInventoryPair> Items;
+
+public:
 	// Sets default values for this component's properties
 	UC_WSInventory();
-
-	const TArray<FInventoryPair>& GetItems() const;
-
+	
 protected:
 	// Called when the game starts
 	virtual void BeginPlay() override;
 
-public:	
-	// Called every frame
-	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
-
 public:
-	void AddItem(AA_WSItem* InItem, int InCount = 1);	// 아이템 추가
-	void RemoveItem(AA_WSItem* InItem, int InCount = 1); // 아이템 빼기
-	void UseItem(uint32 Index, AActor* InTarget, int InCount = 1);	// 아이템 사용
+	virtual const TArray<FInventoryPair>& GetItems() const;
+
+	virtual int32 FindItemIndex(const USG_WSItemMetadata* InMetadata) const;
+	virtual FInventoryPair* FindItem(const USG_WSItemMetadata* InMetadata);
+	
+	virtual void AddItem(AA_WSItem* InItem, int InCount = 1);	// 아이템 추가
+	virtual void RemoveItem(AA_WSItem* InItem, int InCount = 1); // 아이템 빼기
+	virtual void UseItem(uint32 Index, AActor* InTarget, int InCount = 1);	// 아이템 사용
 	
 };

--- a/Source/wunthshin/Interfaces/CommonPawn/CommonPawn.cpp
+++ b/Source/wunthshin/Interfaces/CommonPawn/CommonPawn.cpp
@@ -14,9 +14,11 @@
 #include "wunthshin/Interfaces/DataTableFetcher/DataTableFetcher.h"
 #include "wunthshin/Interfaces/DataTableQuery/DataTableQuery.h"
 #include "wunthshin/Interfaces/Taker/Taker.h"
-#include "wunthshin/Widgets/DamageIndicator/WG_WSDamageIndicator.h"
+#include "wunthshin/Widgets/DamageCounter/WG_WSDamageCounter.h"
 
 // Add default functionality here for any ICommonPawn functions that are not pure virtual.
+
+const FName ICommonPawn::InventoryComponentName = "InventoryComponent";
 
 AwunthshinPlayerState* ICommonPawn::GetPlayerState() const
 {
@@ -32,7 +34,7 @@ void ICommonPawn::UpdatePawnFromDataTable(const FCharacterTableRow* InData)
         if (APawn* PawnCasting = Cast<APawn>(this);
             PawnCasting && (PawnCasting->GetWorld()->IsGameWorld() || PawnCasting->GetWorld()->IsPlayInEditor()))
         {
-            GetDamageIndicators()->Initialize(PawnCasting, {}, GetSkeletalMeshComponent());
+            GetDamageCounters()->Initialize(PawnCasting, {}, GetSkeletalMeshComponent());
         }
     }
 

--- a/Source/wunthshin/Interfaces/CommonPawn/CommonPawn.h
+++ b/Source/wunthshin/Interfaces/CommonPawn/CommonPawn.h
@@ -38,6 +38,8 @@ class WUNTHSHIN_API ICommonPawn
 	virtual void SetHitMontages(const TArray<UAnimMontage*>& InMontages) = 0;
 	
 public:
+	static const FName InventoryComponentName;
+	
 	virtual FName GetAssetName() const = 0;
 
 	COMPONENT_GETTER(UCapsuleComponent, CapsuleComponent);
@@ -48,7 +50,7 @@ public:
 	COMPONENT_GETTER(UChildActorComponent, RightHandComponent);
 	COMPONENT_GETTER(UPawnMovementComponent, PawnMovementComponent);
 	COMPONENT_GETTER(UC_WSSkill, SkillComponent);
-	COMPONENT_GETTER(UDamageIndicatorPool, DamageIndicators);
+	COMPONENT_GETTER(UDamageCounterPool, DamageCounters);
 
 	// 빨리 달리는지 확인하는 함수
 	virtual bool IsFastRunning() const = 0;

--- a/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/SharedInventory/SharedInventory.h
+++ b/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/SharedInventory/SharedInventory.h
@@ -17,10 +17,10 @@ struct FSharedInventory
 	void RemoveItem(const USG_WSItemMetadata* InItemMetadata, const uint32 InCount);
 	void UseItem(uint32 InIndex, AActor* InUser, AActor* InTargetActor, uint32 InCount);
 
-private:
 	int32 FindItemIndex(const USG_WSItemMetadata* InMetadata) const;
 	FInventoryPair* FindItem(const USG_WSItemMetadata* InMetadata);
-	
+
+private:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Item", meta=(AllowPrivateAccess = "true"))
 	TArray<FInventoryPair> ItemsOwned;
 };

--- a/Source/wunthshin/Widgets/DamageCounter/WG_WSDamageCounter.cpp
+++ b/Source/wunthshin/Widgets/DamageCounter/WG_WSDamageCounter.cpp
@@ -1,12 +1,12 @@
 ﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 
-#include "WG_WSDamageIndicator.h"
+#include "WG_WSDamageCounter.h"
 
 #include "Components/TextBlock.h"
 #include "Components/WidgetComponent.h"
 
-UDamageIndicatorPool::UDamageIndicatorPool()
+UDamageCounterPool::UDamageCounterPool()
 {
 	if (static ConstructorHelpers::FClassFinder<UUserWidget> DefaultClass(TEXT("/Script/UMGEditor.WidgetBlueprint'/Game/ThirdPerson/Blueprints/Widgets/BP_WG_WSDamageIndicator.BP_WG_WSDamageIndicator_C'"));
 		DefaultClass.Succeeded())
@@ -15,7 +15,7 @@ UDamageIndicatorPool::UDamageIndicatorPool()
 	}
 }
 
-void UDamageIndicatorPool::Initialize(AActor* InAttachTo, const TFunction<void(UWidgetComponent*)>& InFnPostInitialization, UMeshComponent* InMeshComponent)
+void UDamageCounterPool::Initialize(AActor* InAttachTo, const TFunction<void(UWidgetComponent*)>& InFnPostInitialization, UMeshComponent* InMeshComponent)
 {
 	for (uint32 i = 0; i < MaxAllocation; ++i)
 	{
@@ -41,11 +41,11 @@ void UDamageIndicatorPool::Initialize(AActor* InAttachTo, const TFunction<void(U
 			InFnPostInitialization(WidgetComponent);
 		}
 		
-		Widgets.Push(FDamageIndicatorContext(i, WidgetComponent));
+		Widgets.Push(FDamageCounterContext(i, WidgetComponent));
 	}
 }
 
-void UDamageIndicatorPool::Allocate(const float Damage)
+void UDamageCounterPool::Allocate(const float Damage)
 {
 	// 비트가 플립되지 않은 번호를 찾는다
 	int Available = _tzcnt_u32(AllocationMask) - 1;
@@ -64,8 +64,8 @@ void UDamageIndicatorPool::Allocate(const float Damage)
 	
 	AllocationMask |= 1 << Available;
 	
-	FDamageIndicatorContext& Context = Widgets[Available];
-	UWG_WSDamageIndicator* DamageIndicator = Cast<UWG_WSDamageIndicator>(Context.GetWidget()->GetWidget());
+	FDamageCounterContext& Context = Widgets[Available];
+	UWG_WSDamageCounter* DamageIndicator = Cast<UWG_WSDamageCounter>(Context.GetWidget()->GetWidget());
 
 	// 데미지를 설정하고 Visibility를 바꾼 다음 애니메이션을 재생한다
 	DamageIndicator->GetDamageText()->SetText(FText::FromString(FString::FromInt(static_cast<int32>(Damage))));
@@ -74,7 +74,7 @@ void UDamageIndicatorPool::Allocate(const float Damage)
 
 	// 일정 시간이 지나고 나서 해당 위젯을 해제
 	FTimerDelegate TimerDelegate;
-	TimerDelegate.BindUObject(this, &UDamageIndicatorPool::Deallocate, Context.GetIdentifier());
+	TimerDelegate.BindUObject(this, &UDamageCounterPool::Deallocate, Context.GetIdentifier());
 	Context.GetWidget()->GetWorld()->GetTimerManager().SetTimer
 	(
 		Context.GetTimerHandle(),
@@ -85,7 +85,7 @@ void UDamageIndicatorPool::Allocate(const float Damage)
 	);
 }
 
-void UDamageIndicatorPool::Deallocate(const short InIndex)
+void UDamageCounterPool::Deallocate(const short InIndex)
 {
 	// 위젯을 숨기고 다시 사용 가능함으로 표기
 	Widgets[InIndex].GetWidget()->SetVisibility(false);

--- a/Source/wunthshin/Widgets/DamageCounter/WG_WSDamageCounter.h
+++ b/Source/wunthshin/Widgets/DamageCounter/WG_WSDamageCounter.h
@@ -4,7 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
-#include "WG_WSDamageIndicator.generated.h"
+#include "WG_WSDamageCounter.generated.h"
 
 class UWidgetComponent;
 
@@ -14,7 +14,7 @@ class UCanvasPanel;
  * 
  */
 UCLASS()
-class WUNTHSHIN_API UWG_WSDamageIndicator : public UUserWidget
+class WUNTHSHIN_API UWG_WSDamageCounter : public UUserWidget
 {
 	GENERATED_BODY()
 	
@@ -33,12 +33,12 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FDamageIndicatorContext
+struct FDamageCounterContext
 {
 	GENERATED_BODY()
 
-	FDamageIndicatorContext() = default;
-	explicit FDamageIndicatorContext(const short InIdentifier, UWidgetComponent* InComponent) : Identifier(InIdentifier), Widget(InComponent) {}
+	FDamageCounterContext() = default;
+	explicit FDamageCounterContext(const short InIdentifier, UWidgetComponent* InComponent) : Identifier(InIdentifier), Widget(InComponent) {}
 
 	short GetIdentifier() const { return Identifier; }
 	UWidgetComponent* GetWidget() const { return Widget; }
@@ -56,17 +56,17 @@ private:
 };
 
 UCLASS(BlueprintType)
-class UDamageIndicatorPool : public UObject
+class UDamageCounterPool : public UObject
 {
 	GENERATED_BODY()
 
-	UDamageIndicatorPool();
+	UDamageCounterPool();
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
 	TSubclassOf<UUserWidget> DefaultWidgetClass;
 	
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-	TArray<FDamageIndicatorContext> Widgets;
+	TArray<FDamageCounterContext> Widgets;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
 	int32 ConsecutiveOverflow = 0;


### PR DESCRIPTION
## 개요
인벤토리 컴포넌트의 재사용성을 위해 기존 인벤토리 컴포넌트 롤백
캐릭터의 인벤토리는 상속하여 오버라이드 후 정의하여 기존 인터페이스와 호환

## 수정사항
### 인벤토리 컴포넌트
기존 인벤토리 컴포넌트로 롤백
인벤토리 컴포넌트를 상속하는 캐릭터 인벤토리 컴포넌트 추가

### 데미지 인디케이터 -> 데미지 카운터
이름 변경