### PR TITLE
fix: skill targeting

### DIFF
--- a/Source/wunthshin/Actors/Pawns/NPC/A_WSNPCPawn.cpp
+++ b/Source/wunthshin/Actors/Pawns/NPC/A_WSNPCPawn.cpp
@@ -43,7 +43,6 @@ AA_WSNPCPawn::AA_WSNPCPawn()
 	Skill = CreateDefaultSubobject<UC_WSSkill>(TEXT("SkillComponent"));
 	
 	SetRootComponent(CapsuleComponent);
-	CapsuleComponent->InitCapsuleSize(42.f, 96.f);
 	CapsuleComponent->SetCollisionProfileName("Pawn");
 
 	MeshComponent->SetupAttachment(CapsuleComponent);

--- a/Source/wunthshin/Interfaces/CommonPawn/CommonPawn.cpp
+++ b/Source/wunthshin/Interfaces/CommonPawn/CommonPawn.cpp
@@ -46,7 +46,7 @@ void ICommonPawn::UpdatePawnFromDataTable(const FCharacterTableRow* InData)
 
     if (InData->bCustomCapsuleSize)
     {
-        GetCapsuleComponent()->InitCapsuleSize(InData->Radius, InData->HalfHeight);
+        GetCapsuleComponent()->SetCapsuleSize(InData->Radius, InData->HalfHeight);
         GetSkeletalMeshComponent()->SetRelativeLocation({ 0.f, 0.f, -InData->HalfHeight });
     }
     else


### PR DESCRIPTION
InitCapsuleSize 호출시 캡슐 컴포넌트의 오버랩 업데이트가 발생하지 않음