### PR TITLE
bug/fix: missing metadata

### DIFF
--- a/Source/wunthshin/Components/Weapon/C_WSWeapon.h
+++ b/Source/wunthshin/Components/Weapon/C_WSWeapon.h
@@ -75,7 +75,7 @@ protected:
 	TArray<UAnimMontage*> AttackMontages;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
-	bool bRespawn;
+	bool bRespawn = false;
 
 	//연속 공격 카운트
 	int32 NextAttackIndex = 0;

--- a/Source/wunthshin/Data/Characters/CharacterContext/CharacterContext.h
+++ b/Source/wunthshin/Data/Characters/CharacterContext/CharacterContext.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "wunthshin/Data/Characters/CharacterStats/CharacterStats.h"
 
 #include "CharacterContext.generated.h"
@@ -6,7 +6,7 @@
 class AA_WSCharacter;
 
 USTRUCT(BlueprintType)
-struct FCharacterContext
+struct WUNTHSHIN_API FCharacterContext
 {
 	GENERATED_BODY()
 

--- a/Source/wunthshin/Data/Characters/CharacterStats/CharacterStats.h
+++ b/Source/wunthshin/Data/Characters/CharacterStats/CharacterStats.h
@@ -5,7 +5,7 @@
 struct FWSArchive;
 
 USTRUCT(BlueprintType)
-struct FCharacterMovementModifier
+struct WUNTHSHIN_API FCharacterMovementModifier
 {
 	GENERATED_BODY()
 
@@ -29,7 +29,7 @@ struct FCharacterMovementModifier
 };
 
 USTRUCT(BlueprintType)
-struct FCharacterMovementStats
+struct WUNTHSHIN_API FCharacterMovementStats
 {
 	GENERATED_BODY()
 	virtual ~FCharacterMovementStats() = default;
@@ -69,7 +69,7 @@ private:
 
 // 캐릭터의 스탯을 정의하는 구조체
 USTRUCT(BlueprintType)
-struct FCharacterStats : public FTableRowBase
+struct WUNTHSHIN_API FCharacterStats : public FTableRowBase
 {
     GENERATED_BODY()
 	

--- a/Source/wunthshin/Data/Elements/ElementRowHandle/ElementRowHandle.h
+++ b/Source/wunthshin/Data/Elements/ElementRowHandle/ElementRowHandle.h
@@ -1,11 +1,11 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "ElementRowHandle.generated.h"
 
 // 커스텀 해시가 FDataTableRowHandle에 전역 적용되는 것을 막기 위한 구조체
 USTRUCT(BlueprintType)
-struct FElementRowHandle
+struct WUNTHSHIN_API FElementRowHandle
 {
 	GENERATED_BODY()	
 	

--- a/Source/wunthshin/Data/Elements/ElementTracking/ElementTracking.h
+++ b/Source/wunthshin/Data/Elements/ElementTracking/ElementTracking.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "wunthshin/Data/Elements/ElementRowHandle/ElementRowHandle.h"
 
 #include "ElementTracking.generated.h"
@@ -6,7 +6,7 @@
 DECLARE_LOG_CATEGORY_CLASS(LogElementTracking, Log, All);
 
 USTRUCT()
-struct FElementReactionPair
+struct WUNTHSHIN_API FElementReactionPair
 {
 	GENERATED_BODY()
 
@@ -17,7 +17,7 @@ struct FElementReactionPair
 };
 
 USTRUCT()
-struct FElementTrackingContext 
+struct WUNTHSHIN_API FElementTrackingContext
 {
 	GENERATED_BODY()
 
@@ -28,7 +28,7 @@ struct FElementTrackingContext
 };
 
 USTRUCT()
-struct FElementTrackingMap
+struct WUNTHSHIN_API FElementTrackingMap
 {
 	GENERATED_BODY()
 

--- a/Source/wunthshin/Data/Items/DamageEvent/WSDamageEvent.h
+++ b/Source/wunthshin/Data/Items/DamageEvent/WSDamageEvent.h
@@ -3,7 +3,7 @@
 
 class ICommonPawn;
 
-struct FWSDamageEvent : public FDamageEvent
+struct WUNTHSHIN_API FWSDamageEvent : public FDamageEvent
 {
 	FGuid AttackID;
 

--- a/Source/wunthshin/Data/Items/InventoryPair/InventoryPair.h
+++ b/Source/wunthshin/Data/Items/InventoryPair/InventoryPair.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "InventoryPair.generated.h"
 
@@ -6,7 +6,7 @@ class USG_WSItemMetadata;
 class UInventoryEntryData;
 
 USTRUCT(BlueprintType)
-struct FInventoryPair
+struct WUNTHSHIN_API FInventoryPair
 {
 	GENERATED_BODY()
 

--- a/Source/wunthshin/Data/Items/WeaponContext/WeaponContext.h
+++ b/Source/wunthshin/Data/Items/WeaponContext/WeaponContext.h
@@ -1,10 +1,10 @@
-﻿#pragma once
+#pragma once
 #include "wunthshin/Data/Modifiers/WeaponModifier/WeaponModifier.h"
 
 #include "WeaponContext.generated.h"
 
 USTRUCT(BlueprintType)
-struct FWeaponContext
+struct WUNTHSHIN_API FWeaponContext
 {
 	GENERATED_BODY()
 	

--- a/Source/wunthshin/Data/Modifiers/WeaponModifier/WeaponModifier.h
+++ b/Source/wunthshin/Data/Modifiers/WeaponModifier/WeaponModifier.h
@@ -1,9 +1,9 @@
-﻿#pragma once
+#pragma once
 
 #include "WeaponModifier.generated.h"
 
 USTRUCT(BlueprintType)
-struct FWeaponModifier
+struct WUNTHSHIN_API FWeaponModifier
 {
 	GENERATED_BODY()
 	

--- a/Source/wunthshin/Data/NPCs/NPCStats/NPCStats.h
+++ b/Source/wunthshin/Data/NPCs/NPCStats/NPCStats.h
@@ -6,7 +6,7 @@
 
 // NPC의 스탯을 정의하는 구조체
 USTRUCT(BlueprintType)
-struct FNPCStats : public FCharacterStats
+struct WUNTHSHIN_API FNPCStats : public FCharacterStats
 {
     GENERATED_BODY()
 

--- a/Source/wunthshin/Data/Skills/SkillTableRow/SkillTableRow.h
+++ b/Source/wunthshin/Data/Skills/SkillTableRow/SkillTableRow.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "LevelSequence.h"
 
 #include "SkillTableRow.generated.h"
@@ -44,7 +44,7 @@ struct WUNTHSHIN_API FSkillParameter
 };
 
 USTRUCT()
-struct FSkillTableRow : public FTableRowBase
+struct WUNTHSHIN_API FSkillTableRow : public FTableRowBase
 {
 	GENERATED_BODY()
 

--- a/Source/wunthshin/Interfaces/InventoryComponent/InventoryComponent.h
+++ b/Source/wunthshin/Interfaces/InventoryComponent/InventoryComponent.h
@@ -4,10 +4,10 @@
 
 #include "CoreMinimal.h"
 #include "UObject/Interface.h"
+#include "wunthshin/Data/Items/InventoryPair/InventoryPair.h"
 #include "InventoryComponent.generated.h"
 
 class AA_WSItem;
-struct FInventoryPair;
 class USG_WSItemMetadata;
 
 // This class does not need to be modified.

--- a/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/ItemSubsystem.cpp
+++ b/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/ItemSubsystem.cpp
@@ -34,3 +34,8 @@ USG_WSItemMetadata* UItemSubsystem::GetMetadata(const FName& InAssetName)
 {
 	return FItemSubsystemUtility::GetMetadataTemplate(Metadata, InAssetName);
 }
+
+FSharedInventory& UItemSubsystem::GetSharedInventory() 
+{ 
+	return SharedInventory; 
+}

--- a/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/ItemSubsystem.h
+++ b/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/ItemSubsystem.h
@@ -6,7 +6,6 @@
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "GenericPlatform/GenericPlatformMisc.h"
 #include "SharedInventory/SharedInventory.h"
-#include "wunthshin/Data/Items/ItemMetadata/SG_WSItemMetadata.h"
 
 #include "wunthshin/Interfaces/DataTableQuery/DataTableQuery.h"
 #include "wunthshin/Interfaces/ItemMetadataGetter/ItemMetadataGetter.h"
@@ -39,6 +38,6 @@ public:
 	
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual USG_WSItemMetadata* GetMetadata(const FName& InAssetName) override;
-	FSharedInventory& GetSharedInventory() { return SharedInventory; }
+	FSharedInventory& GetSharedInventory();
 	UDataTable* GetDataTable() const { return DataTable; }
 };

--- a/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/SharedInventory/SharedInventory.cpp
+++ b/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/SharedInventory/SharedInventory.cpp
@@ -1,9 +1,14 @@
-﻿#include "SharedInventory.h"
+#include "SharedInventory.h"
 
 #include "wunthshin/Data/Items/InventoryPair/InventoryPair.h"
 #include "wunthshin/Subsystem/WorldSubsystem/WorldStatus/WorldStatusSubsystem.h"
 
 DEFINE_LOG_CATEGORY(LogSharedInventory);
+
+const TArray<FInventoryPair>& FSharedInventory::GetItems() const 
+{ 
+	return ItemsOwned; 
+}
 
 void FSharedInventory::AddItem(const USG_WSItemMetadata* InItemMetadata, const uint32 InCount)
 {

--- a/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/SharedInventory/SharedInventory.h
+++ b/Source/wunthshin/Subsystem/GameInstanceSubsystem/Item/SharedInventory/SharedInventory.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "wunthshin/Data/Items/InventoryPair/InventoryPair.h"
 
 #include "SharedInventory.generated.h"
@@ -8,11 +8,11 @@ DECLARE_LOG_CATEGORY_EXTERN(LogSharedInventory, Log, All);
 class USG_WSItemMetadata;
 
 USTRUCT(BlueprintType)
-struct FSharedInventory
+struct WUNTHSHIN_API FSharedInventory
 {
 	GENERATED_BODY()
 
-	const TArray<FInventoryPair>& GetItems() const { return ItemsOwned; }
+	const TArray<FInventoryPair>& GetItems() const;
 	void AddItem(const USG_WSItemMetadata* InItemMetadata, const uint32 InCount);
 	void RemoveItem(const USG_WSItemMetadata* InItemMetadata, const uint32 InCount);
 	void UseItem(uint32 InIndex, AActor* InUser, AActor* InTargetActor, uint32 InCount);

--- a/Source/wunthshin/Subsystem/Utility.h
+++ b/Source/wunthshin/Subsystem/Utility.h
@@ -1,19 +1,15 @@
-﻿#pragma once
+#pragma once
 #include "wunthshin/Interfaces/DataTableFetcher/DataTableFetcher.h"
 #include "wunthshin/Interfaces/ItemMetadataGetter/ItemMetadataGetter.h"
 #include "wunthshin/Data/Effects/EffectRowHandle/EffectRowHandle.h"
 
-#if WITH_EDITOR & !UE_BUILD_SHIPPING_WITH_EDITOR
-// 블루프린트 객체가 리컴파일하기 전까지 데이터 테이블이 수정된 사항이 반영되지 않음
-// 블루프린트에서 설정된 에디터 메타데이터를 강제로 갱신
+// 에디터: 블루프린트 객체가 리컴파일하기 전까지 데이터 테이블이 수정된 사항이 반영되지 않음
+// 스탠드얼론: 에디터 서브시스템의 객체로 설정된 데이터가 소실되어 채워야 함
 #define BLUEPRINT_REFRESH_EDITOR \
 		if (!GetClass()->IsNative() && GetWorld()->IsGameWorld()) \
 		{ \
 		FetchAsset(AssetName); \
 		}
-#else
-#define BLUEPRINT_REFRESH_EDITOR __nop();
-#endif
 
 #if WITH_EDITOR & !UE_BUILD_SHIPPING_WITH_EDITOR
 #include "Editor.h"

--- a/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/ElementTicket/ElementReactTicket.h
+++ b/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/ElementTicket/ElementReactTicket.h
@@ -1,10 +1,10 @@
-﻿#pragma once
+#pragma once
 #include "wunthshin/Data/Elements/ElementRowHandle/ElementRowHandle.h"
 #include "wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/EventTicket.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(LogElementTicket, Log, All);
 
-struct FElementReactTicket : public FEventTicket
+struct WUNTHSHIN_API FElementReactTicket : public FEventTicket
 {
 public:
 	FElementRowHandle ElementHandle;
@@ -14,7 +14,7 @@ public:
 	virtual void Execute(UWorld* InWorld) override;
 };
 
-struct FElementReactRevokeTicket : public FEventTicket
+struct WUNTHSHIN_API FElementReactRevokeTicket : public FEventTicket
 {
 public:
 	AActor* TargetActor;

--- a/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/EventTicket.h
+++ b/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/EventTicket.h
@@ -1,6 +1,6 @@
-﻿#pragma once
+#pragma once
 
-struct FEventTicket
+struct WUNTHSHIN_API FEventTicket
 {
 public:
 	virtual ~FEventTicket() = default;

--- a/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/ItemTicket/ItemTicket.h
+++ b/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/ItemTicket/ItemTicket.h
@@ -1,9 +1,9 @@
-﻿#pragma once
+#pragma once
 #include "wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/EventTicket.h"
 
 class USG_WSItemMetadata;
 
-struct FItemTicket : public FEventTicket
+struct WUNTHSHIN_API FItemTicket : public FEventTicket
 {
 	friend class UWorldStatusSubsystem;
 

--- a/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/SkillTicket/SkillTickets.h
+++ b/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/SkillTicket/SkillTickets.h
@@ -1,11 +1,11 @@
-﻿#pragma once
+#pragma once
 #include "wunthshin/Data/Skills/SkillRowHandle/SkillRowHandle.h"
 #include "wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/EventTicket.h"
 
 class UO_WSBaseSkill;
 class ICommonPawn;
 
-struct FSkillStartTicket : public FEventTicket
+struct WUNTHSHIN_API FSkillStartTicket : public FEventTicket
 {
 public:
 	FSkillRowHandle SkillHandle;
@@ -16,7 +16,7 @@ public:
 	virtual void Execute(UWorld* InWorld) override;
 };
 
-struct FSkillRevokeTicket : public FEventTicket
+struct WUNTHSHIN_API FSkillRevokeTicket : public FEventTicket
 {
 public:
 	FSkillRowHandle SkillHandle;

--- a/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/WeaponTicket/WeaponModifierTicket.h
+++ b/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/WeaponTicket/WeaponModifierTicket.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "wunthshin/Data/Modifiers/WeaponModifier/WeaponModifier.h"
 #include "wunthshin/Subsystem/WorldSubsystem/WorldStatus/EventTicket/EventTicket.h"
 
@@ -6,7 +6,7 @@ class UC_WSWeapon;
 
 DECLARE_LOG_CATEGORY_EXTERN(LogWeaponModifier, Log, All);
 
-struct FWeaponModifierTicket : public FEventTicket
+struct WUNTHSHIN_API FWeaponModifierTicket : public FEventTicket
 {
 public:
 	UC_WSWeapon* WeaponComponent;
@@ -17,7 +17,7 @@ public:
 	virtual void Execute(UWorld* InWorld) override;
 };
 
-struct FWeaponModifierRevokeTicket : public FEventTicket
+struct WUNTHSHIN_API FWeaponModifierRevokeTicket : public FEventTicket
 {
 public:
 	UC_WSWeapon* WeaponComponent;

--- a/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/WorldStatusSubsystem.h
+++ b/Source/wunthshin/Subsystem/WorldSubsystem/WorldStatus/WorldStatusSubsystem.h
@@ -22,7 +22,7 @@ class USG_WSItemMetadata;
 class AA_WSItem;
 
 USTRUCT(BlueprintType)
-struct FDamageTakenArray
+struct WUNTHSHIN_API FDamageTakenArray
 {
 	GENERATED_BODY()
 

--- a/Source/wunthshin/Widgets/WG_WSUserWidgetBase.cpp
+++ b/Source/wunthshin/Widgets/WG_WSUserWidgetBase.cpp
@@ -39,6 +39,10 @@ void UWG_WSUserWidgetBase::SetVisibleWidget(bool bIsVisible)
 void UWG_WSUserWidgetBase::OnVisibleWidget()
 {
 	SetVisibleWidget(true);
+	FInputModeUIOnly UIOnly;
+	UIOnly.SetWidgetToFocus(TakeWidget());
+	UIOnly.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+
 	GetPlayerContext().GetPlayerController()->SetInputMode(FInputModeUIOnly{});
 	GetPlayerContext().GetPlayerController()->SetShowMouseCursor(true);
 }


### PR DESCRIPTION
## 개요
블루프린트로 만들어진 객체에 에디터 서브시스템의 아이템 메타데이터가 설정되고, Standalone에서는 해당 객체가 소실되기 때문에 아이템 정보를 갱신해야함